### PR TITLE
Sort keys in SASampler, ZekeSampler, NQSSampler

### DIFF
--- a/tytan/sampler.py
+++ b/tytan/sampler.py
@@ -19,6 +19,9 @@ class SASampler:
         keys = list(set(k for tup in qubo.keys() for k in tup))
         #print(keys)
 
+        #要素のソート
+        keys.sort()
+        
         #抽出した要素のindexマップを作成
         index_map = {k: v for v, k in enumerate(keys)}
         #print(index_map)
@@ -112,6 +115,9 @@ class ZekeSampler:
         keys = list(set(k for tup in qubo.keys() for k in tup))
         #print(keys)
 
+        #要素のソート
+        keys.sort()
+        
         #抽出した要素のindexマップを作成
         index_map = {k: v for v, k in enumerate(keys)}
         #print(index_map)
@@ -236,6 +242,9 @@ class NQSSampler():
         keys = list(set(k for tup in qubo.keys() for k in tup))
         #print(keys)
 
+        #要素のソート
+        keys.sort()
+        
         #抽出した要素のindexマップを作成
         index_map = {k: v for v, k in enumerate(keys)}
         #print(index_map)


### PR DESCRIPTION
結果の中の辞書の中の変数名（量子ビット名）をソートしておいたほうが見やすいかなと思い、そのために各サンプラーの冒頭にkeysのソートを追加する提案です。 GASamplerでは動作確認済みですが、他のサンプラーでは動作確認していません。冒頭の構造が共通なのでいけるかなと思いますが。。