### PR TITLE
Feature/add qubo input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 QUBO形式
 
 ## 問題サイズ
-ローカル：1,000量子ビット程度   
+ローカル：1,000量子ビット程度
 API経由：1,000-10万量子ビット程度
 
 ## インストール
@@ -45,6 +45,45 @@ expr = 3*x**2 + 2*x*y + 4*y**2 + z**2 + 2*x*z + 2*y*z
 
 # Compileクラスを使用して、QUBOを取得
 Q, offset = qubo.Compile(expr).get_qubo()
+
+# サンプラーを選択
+solver = sampler.SASampler()
+
+# 計算
+result = solver.run(Q, shots=100)
+print(result)
+```
+
+numpyの場合
+```
+from tytan import *
+import numpy as np
+
+# QUBO行列を記述（上三角行列）
+matrix = np.array([[3, 2, 2], [0, 4, 2], [0, 0, 2]])
+
+# Compileクラスを使用して、QUBOを取得。
+Q, offset = qubo.Compile(matrix).get_qubo()
+
+# サンプラーを選択
+solver = sampler.SASampler()
+
+# 計算
+result = solver.run(Q, shots=100)
+print(result)
+```
+
+pandas（csv）の場合
+```
+from tytan import *
+import pandas as pd
+
+# QUBO行列を取得（csv, 上三角行列）
+# header, index名を設定した場合は変数名が設定した名前になる。
+csv_data = pd.read_csv('qubo.csv')
+
+# Compileクラスを使用して、QUBOを取得
+Q, offset = qubo.Compile(csv_data).get_qubo()
 
 # サンプラーを選択
 solver = sampler.SASampler()

--- a/tytan/qubo.py
+++ b/tytan/qubo.py
@@ -1,41 +1,89 @@
 import sympy as sp
+import numpy as np
+import pandas as pd
 
 class Compile:
     def __init__(self, expr):
         self.expr = expr
-    
+
     def get_qubo(self):
-        
-        #展開されていない式は展開する
-        self.expr = sp.expand(self.expr)
-        
-        # 式で使用されている変数を確認
-        for item in self.expr.free_symbols:
-            # バイナリなので、二次の項を一次の項に減らす代入
-            self.expr = self.expr.subs([(item**2, item)])
+        """get qubo data
 
-        # 係数を抜き出す
-        coeff_dict = self.expr.as_coefficients_dict()
-        offset = coeff_dict.get(1, 0)
-        
-        #print(offset)
-        
-        expr2 = self.expr - offset
-        
-        coeff_dict = dict(expr2.as_coefficients_dict())
+        Raises:
+            TypeError: Input type is sympy, numpy or pandas.
 
-        # QUBOに格納開始
-        qubo = {}
-        for key, value in coeff_dict.items():
-            # 一次の項の格納
-            if key.count_ops() == 0:
-                qubo[(str(key), str(key))] = value
+        Returns:
+            Tuple: qubo is dict. offset is float.
+        """
 
-            # 二次の項の格納
-            if key.count_ops() == 1:
-                arr = []
-                for term in key.args:
-                    arr.append(term)
-                qubo[(str(arr[0]), str(arr[1]))] = value
+        # sympy
+        if isinstance(self.expr, (sp.core.add.Add, sp.core.symbol.Symbol)):
+            #展開されていない式は展開する
+            self.expr = sp.expand(self.expr)
 
-        return qubo, offset
+            # 式で使用されている変数を確認
+            for item in self.expr.free_symbols:
+                # バイナリなので、二次の項を一次の項に減らす代入
+                self.expr = self.expr.subs([(item**2, item)])
+
+            # 係数を抜き出す
+            coeff_dict = self.expr.as_coefficients_dict()
+            offset = coeff_dict.get(1, 0)
+
+            # print(offset)
+
+            expr2 = self.expr - offset
+
+            coeff_dict = dict(expr2.as_coefficients_dict())
+
+            # print(coeff_dict)
+
+            # QUBOに格納開始
+            qubo = {}
+            for key, value in coeff_dict.items():
+                # 一次の項の格納
+                if key.count_ops() == 0:
+                    qubo[(str(key), str(key))] = value
+
+                # 二次の項の格納
+                if key.count_ops() == 1:
+                    arr = []
+                    for term in key.args:
+                        arr.append(term)
+                    qubo[(str(arr[0]), str(arr[1]))] = value
+
+            return qubo, offset
+
+        # numpy
+        elif isinstance(self.expr, np.ndarray):
+            # 係数
+            offset = 0
+
+            # QUBOに格納開始
+            qubo = {}
+            for i, r in enumerate(self.expr):
+                for j, c in enumerate(r):
+                    if i <= j:
+                        qubo[(f'q{i}', f'q{j}')] = c
+
+            return qubo, offset
+
+        # pandas
+        elif isinstance(self.expr, pd.core.frame.DataFrame):
+            # 係数
+            offset = 0
+
+            # QUBOに格納開始
+            qubo = {}
+            for i, r in self.expr.iterrows():
+                for j, c in enumerate(r):
+                    if i <= j and c != 0:
+                        if self.expr.columns.dtype == 'object':
+                            qubo[(self.expr.columns[i], self.expr.columns[j])] = c
+                        else:
+                            qubo[(f'q{i}', f'q{j}')] = c
+
+            return qubo, offset
+
+        else:
+            raise TypeError("Input type is sympy, numpy or pandas.")

--- a/tytan/qubo.py
+++ b/tytan/qubo.py
@@ -75,13 +75,17 @@ class Compile:
 
             # QUBOに格納開始
             qubo = {}
-            for i, r in self.expr.iterrows():
+            for i, r in enumerate(self.expr.values):
                 for j, c in enumerate(r):
                     if i <= j and c != 0:
+                        row_name, col_name = f'q{i}', f'q{j}'
+                        if self.expr.index.dtype == 'object':
+                            row_name = self.expr.index[i]
+
                         if self.expr.columns.dtype == 'object':
-                            qubo[(self.expr.columns[i], self.expr.columns[j])] = c
-                        else:
-                            qubo[(f'q{i}', f'q{j}')] = c
+                            col_name = self.expr.columns[j]
+
+                        qubo[(row_name, col_name)] = c
 
             return qubo, offset
 


### PR DESCRIPTION
## 変更の概要
numpy, csv, pandasの入力インターフェイス #4 を追加。

numpyはnumpy.ndarray形式。
pandasはpandas.DataFrame形式に対応。
csvはpandasから入力させることにより対応。

## 変更内容
qubo.pyのCompileクラスの引数を型チェックにより条件分岐させた。

## 使用方法
README.md に追記
今までのsympy方式に関しては操作変更なし。

## 備考
networkxを追加予定。