### PR TITLE
READMEのサンプルコード２を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ for r in result:
 from tytan import *
 
 #量子ビットを用意（まとめて定義）
-q = symbols_list([3, 3])
+q = symbols_list([3, 3], 'q{}_{}')
 print(q)
 
 #各行に1つだけ1


### PR DESCRIPTION
symbols_list() の 第2引数は省略できなくなったので、
READMEのサンプルコード２を修正しました。
